### PR TITLE
Hide task done checkbox

### DIFF
--- a/public/stylesheets/tt.css
+++ b/public/stylesheets/tt.css
@@ -1164,6 +1164,11 @@ a.description {
 	filter: alpha(opacity=100);
 	opacity: 1.0;
 }
+
+#task_list [name="task[done]"] {
+    display: none;
+}
+
 .content_body {
 	background-color: #FFFFFF;
 }

--- a/public/stylesheets/tt.css
+++ b/public/stylesheets/tt.css
@@ -1165,7 +1165,24 @@ a.description {
 	opacity: 1.0;
 }
 
-#task_list [name="task[done]"] {
+.task input[type="checkbox"][name="task[done]"] {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    position: absolute;
+    bottom: -1px;
+    left: 37px;
+    color: #c00;
+    background-color: transparent;
+    font-weight: bold;
+    font-size: 10px;
+}
+
+.task input[type="checkbox"][name="task[done]"]::after {
+    content: "Close task";
+}
+
+.task:not(:hover) input[type="checkbox"][name="task[done]"]::after {
     display: none;
 }
 


### PR DESCRIPTION
Too easy to accidentally close a task and not be able to reopen when trying to start timer or add time to task.